### PR TITLE
Make demo repos usable when `ALLOW_WIP` is False

### DIFF
--- a/pfsc/handlers/load.py
+++ b/pfsc/handlers/load.py
@@ -313,10 +313,6 @@ class SourceLoader(Handler):
             self.check_repo_read_permission(rp, pfsc.constants.WIP_TAG,
                                             action='load work in progress from')
 
-    def confirm(self, versions):
-        for vers in versions:
-            self.check_wip_mode(vers, subject='Modules', verb='loaded')
-
     def go_ahead(self, libpaths, versions, cache_code):
         source_lookup = {}
         for libpath, vers in zip(libpaths, versions):

--- a/pfsc/handlers/repo.py
+++ b/pfsc/handlers/repo.py
@@ -106,8 +106,6 @@ class RepoLoader(RepoTaskHandler):
         self.version = vers.full
         self.is_wip = vers.isWIP
 
-        self.check_wip_mode(vers, subject='Repos', verb='opened')
-
         if ri.is_demo():
             msg = None
             if not check_config("PROVIDE_DEMO_REPOS"):
@@ -120,6 +118,8 @@ class RepoLoader(RepoTaskHandler):
             ri.user = demo_username
             true_repopath = ri.rebuild_libpath()
             self.repo_info = RepoInfo(true_repopath)
+        else:
+            self.check_wip_mode(vers, subject='Repos', verb='opened')
 
         # Both the repopath and the version we're finally ready to try to load
         # can be different from the values the user passed. The repopath can
@@ -191,6 +191,10 @@ class RepoLoader(RepoTaskHandler):
         elif is_demo:
             self.will_make_demo = True
             self.will_build = True
+            self.require_in_session(
+                pfsc.constants.DEMO_USERNAME_SESSION_KEY,
+                self.repo_info.user
+            )
         elif is_clonable and doClone:
             self.will_clone = True
             if doBuild:

--- a/pfsc/handlers/write.py
+++ b/pfsc/handlers/write.py
@@ -18,6 +18,8 @@
 
 import time
 
+from flask import has_request_context
+
 import pfsc.constants
 from pfsc.excep import PfscExcep, PECode
 from pfsc.handlers import RepoTaskHandler, SocketHandler, Handler
@@ -246,6 +248,12 @@ class WriteHandler(RepoTaskHandler):
         ir = self.writerepos | self.buildrepos
         for aw in self.autowriters:
             ir |= aw.get_implicated_repopaths()
+        if ir and has_request_context():
+            # Only need this for demo repos, but doesn't hurt in other cases,
+            # so don't waste time checking if any repo is a demo repo.
+            self.require_in_session(
+                pfsc.constants.DEMO_USERNAME_SESSION_KEY
+            )
         self.implicated_repopaths = ir
 
     def go_ahead(self, writepaths, writetexts, shadowonly, buildpaths, recursives, autowrites):


### PR DESCRIPTION
Fixes #1 

There were several issues:
    
* RepoLoader
  - Was calling `self.check_wip_mode()` even for demo repos, which it should not do.
  - Needed the demo username to be available in a simulated `session` during async processing.
* SourceLoader
  - Had a redundant `self.confirm()`, which we now remove entirely. The `self.check_permissions()`
    method already performs exactly the required check.
* WriteHandler
  - Like the `RepoLoader`, needed the demo username to be available in a simulated `session`
    during async processing.

As part of this fix, we now provide the facility to set a simulated session for async processing.