### PR TITLE
Add vers nums to certain URLs

### DIFF
--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ cp = ConfigParser()
 cp.read(os.path.join(BASE_DIR, 'pfsc.ini'))
 DEFAULT_VERSIONS = {
     name: cp.get('versions', name)
-    for name in ['ise', 'elkjs', 'mathjax', 'pyodide', 'examp']
+    for name in ['ise', 'elkjs', 'mathjax', 'pyodide', 'examp', 'pdf']
 }
 
 
@@ -194,6 +194,12 @@ class Config:
     # we cannot serve the mathworker script over a CDN. However, we can decide
     # whether to serve it minified or not.
     MATHWORKER_SERVE_MINIFIED = bool(int(os.getenv("MATHWORKER_SERVE_MINIFIED", 1)))
+
+    PDFJS_VERSION = os.getenv("PDFJS_VERSION", DEFAULT_VERSIONS['pdf'])
+    # Note: We cannot use jsdelivr to serve pdfjs, since (a) it will not serve
+    # html, and (b) pdfjs uses a worker, which must come from the same origin
+    # as the html. Eventually we may provide a config option to set the URL
+    # from which pdfjs's `viewer.html` should be served.
 
     # When loading locally from `/static/...`, some assets have a debug version.
     ELK_DEBUG = bool(int(os.getenv("ELK_DEBUG", 0)))

--- a/pfsc.ini
+++ b/pfsc.ini
@@ -4,3 +4,4 @@ elkjs = 0.8.1
 mathjax = 3.0.1
 pyodide = 0.21.0
 examp = 0.22.8
+pdf = 3.0.0

--- a/pfsc/__init__.py
+++ b/pfsc/__init__.py
@@ -196,6 +196,9 @@ def make_app(config_name=None):
     from . import rq
     rq.init_app(app)
 
+    from pfsc.blueprints import vstat
+    app.register_blueprint(vstat.bp, url_prefix=PREFIX)
+
     from pfsc.blueprints import root
     app.register_blueprint(root.bp, url_prefix=PREFIX)
 
@@ -235,9 +238,9 @@ def make_app(config_name=None):
         html = proxy_or_render("ERR_404_PROXY_URL", "error.html",
             title="Proofscape Error",
             css=[
-                url_for('static', filename='css/base.css'),
+                url_for('vstat.static', filename='css/base.css'),
             ],
-            img_src=url_for('static', filename='img/404.png'),
+            img_src=url_for('vstat.static', filename='img/404.png'),
             msg="Page not found!",
         )
         return html, 404
@@ -255,9 +258,9 @@ def make_app(config_name=None):
         html = proxy_or_render("ERR_500_PROXY_URL", "error.html",
             title="Proofscape Error",
             css=[
-                url_for('static', filename='css/base.css'),
+                url_for('vstat.static', filename='css/base.css'),
             ],
-            img_src=url_for('static', filename='img/500.png'),
+            img_src=url_for('vstat.static', filename='img/500.png'),
             msg="Internal System Error!",
         )
         return html, 500

--- a/pfsc/__init__.py
+++ b/pfsc/__init__.py
@@ -29,7 +29,7 @@ from pfsc.constants import REDIS_CHANNEL, ISE_PREFIX
 from pfsc.excep import PfscExcep, PECode
 from config import config_lookup, ProductionConfig
 
-__version__ = '0.23.6-dev'
+__version__ = '0.24.0-dev'
 
 socketio = SocketIO()
 pfsc_cli = AppGroup('pfsc')

--- a/pfsc/blueprints/auth.py
+++ b/pfsc/blueprints/auth.py
@@ -67,7 +67,7 @@ def login_page():
         allow_github_logins=check_config("ALLOW_GITHUB_LOGINS"),
         allow_bitbucket_logins=check_config("ALLOW_BITBUCKET_LOGINS"),
         css=[
-            url_for('static', filename='css/login.css'),
+            url_for('vstat.static', filename='css/login.css'),
         ]
     )
 
@@ -101,7 +101,7 @@ def login_success():
         auto_close=auto_close,
         auto_close_delay=auto_close_delay,
         css=[
-            url_for('static', filename='css/login.css'),
+            url_for('vstat.static', filename='css/login.css'),
         ]
     )
 

--- a/pfsc/blueprints/vstat.py
+++ b/pfsc/blueprints/vstat.py
@@ -1,0 +1,42 @@
+# --------------------------------------------------------------------------- #
+#   Proofscape Server                                                         #
+#                                                                             #
+#   Copyright (c) 2011-2022 Proofscape contributors                           #
+#                                                                             #
+#   Licensed under the Apache License, Version 2.0 (the "License");           #
+#   you may not use this file except in compliance with the License.          #
+#   You may obtain a copy of the License at                                   #
+#                                                                             #
+#       http://www.apache.org/licenses/LICENSE-2.0                            #
+#                                                                             #
+#   Unless required by applicable law or agreed to in writing, software       #
+#   distributed under the License is distributed on an "AS IS" BASIS,         #
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  #
+#   See the License for the specific language governing permissions and       #
+#   limitations under the License.                                            #
+# --------------------------------------------------------------------------- #
+
+"""
+This blueprint provides an easy way to generate URLs for static assets defined
+here in the pfsc-server project (as opposed to linked from other projects) so
+that they include pfsc-server's version number.
+
+For example,
+
+    url_for('vstat.static', filename='css/base.css')
+
+will generate a URL like
+
+    /static/v0.23.6/css/base.css
+"""
+
+from flask import Blueprint
+
+from pfsc import __version__
+
+
+bp = Blueprint(
+    'vstat', __name__,
+    static_folder='../../static',
+    static_url_path=f'static/v{__version__}',
+)

--- a/pfsc/handlers/app.py
+++ b/pfsc/handlers/app.py
@@ -750,6 +750,7 @@ class AppLoader(Handler):
             'prpoURL': current_app.config.get("PRPO_URL"),
             'prpoVersion': current_app.config.get("PRPO_VERSION"),
             'loginsPossible': logins_are_possible(),
+            'pdfjsURL': url_for('static', filename=f'pdfjs/v{current_app.config["PDFJS_VERSION"]}/web/viewer.html'),
         }
 
         if current_app.config["IS_OCA"]:

--- a/pfsc/handlers/user.py
+++ b/pfsc/handlers/user.py
@@ -179,7 +179,7 @@ class UserInfoExporter(UserHandler):
             thing_to_export=thing_to_export,
             download_url=download_url,
             css=[
-                url_for('static', filename='css/centered_justified.css'),
+                url_for('vstat.static', filename='css/centered_justified.css'),
             ],
         )
         self.set_response_field('html', html)

--- a/pfsc/methods.py
+++ b/pfsc/methods.py
@@ -164,7 +164,7 @@ def handle_and_download(handler_class, info_dict, room=None,
             "download_error.html",
             err_msg=err_msg,
             css=[
-                url_for('static', filename='css/base.css'),
+                url_for('vstat.static', filename='css/base.css'),
             ],
         )
 

--- a/pfsc/templates/login.html
+++ b/pfsc/templates/login.html
@@ -30,7 +30,7 @@
   {% if allow_github_logins %}
   <a id="ghbutton" class="oAuthButton" href="#" onclick="gotoCond('{{ url_for('auth.login_with_provider', prov='gh', level='user') }}')">
     <svg width="300px" height="60px" xmlns="http://www.w3.org/2000/svg">
-      <image x="3" y="3" height="53px" width="53px" href="{{ url_for('static', filename='img/ghlogo.png') }}"/>
+      <image x="3" y="3" height="53px" width="53px" href="{{ url_for('vstat.static', filename='img/ghlogo.png') }}"/>
       <text x="80" y="38" fill="#ddd">Sign in with GitHub</text>
     </svg>
   </a>
@@ -43,7 +43,7 @@
   {% if allow_bitbucket_logins %}
   <a id="bbbutton" class="oAuthButton" href="#" onclick="gotoCond('{{ url_for('auth.login_with_provider', prov='bb', level='user') }}')">
     <svg width="300px" height="60px" xmlns="http://www.w3.org/2000/svg">
-      <image x="8" y="8" height="43px" width="44px" href="{{ url_for('static', filename='img/bblogo.png') }}"/>
+      <image x="8" y="8" height="43px" width="44px" href="{{ url_for('vstat.static', filename='img/bblogo.png') }}"/>
       <text x="65" y="38" fill="#222">Sign in with BitBucket</text>
     </svg>
   </a>

--- a/tests/test_app_loader.py
+++ b/tests/test_app_loader.py
@@ -444,6 +444,11 @@ def normalize_gids(state):
                             gids.append(gid)
 
 
+def normalize_served_state(state):
+    del state['pdfjsURL']
+    normalize_gids(state)
+
+
 @pytest.mark.parametrize(['args', 'expected'], (
     (args_0, state_0),
     (args_1, state_1),
@@ -462,7 +467,7 @@ def test_app_loader(app, args, expected):
             assert "CSRF" in state
             del state["CSRF"]
 
-            normalize_gids(state)
+            normalize_served_state(state)
 
             computed = json.dumps(state, indent=4)
             print(computed)


### PR DESCRIPTION
Addresses the need for cache busting for `pfsc-pdf`, as well as for `pfsc-server`'s native static files, by adding version numbers to the URLs for these resources.

#### Breaking changes

`pfsc-manage`: the MCA deployment will have to adapt to the new URLs for the native static assets

#### Other changes

The URL for pdfjs is now a part of the served state. `pfsc-ise` should now use this to load `viewer.html` in pdf panels.