### PR TITLE
D.R.Y. with version numbers

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,7 +17,6 @@
 # --------------------------------------------------------------------------- #
 
 import os
-from configparser import ConfigParser
 
 from dotenv import load_dotenv
 # Load pfsc-server/instance/.env
@@ -31,13 +30,7 @@ if bool(int(os.getenv("LOAD_PFSC_CONF_FROM_STANDARD_DEPLOY_DIR", 0))):
     load_dotenv(PFSC_CONF_PATH, override=True)
 
 
-# Default versions for supporting software are set in pfsc.ini
-cp = ConfigParser()
-cp.read(os.path.join(BASE_DIR, 'pfsc.ini'))
-DEFAULT_VERSIONS = {
-    name: cp.get('versions', name)
-    for name in ['ise', 'pdf']
-}
+DEFAULT_ISE_VERSION = '25.0'
 
 
 def format_url_prefix(raw):
@@ -172,7 +165,7 @@ class Config:
 
     # Static assets:
 
-    ISE_VERSION = os.getenv("ISE_VERSION", DEFAULT_VERSIONS['ise'])
+    ISE_VERSION = os.getenv("ISE_VERSION", DEFAULT_ISE_VERSION)
     ISE_SERVE_MINIFIED = bool(int(os.getenv("ISE_SERVE_MINIFIED", 0)))
     # Since a worker script must obey the same-origin policy
     #   https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker
@@ -186,12 +179,6 @@ class Config:
     ELKJS_SERVE_LOCALLY = bool(int(os.getenv("ELKJS_SERVE_LOCALLY", 0)))
     MATHJAX_SERVE_LOCALLY = bool(int(os.getenv("MATHJAX_SERVE_LOCALLY", 0)))
     PYODIDE_SERVE_LOCALLY = bool(int(os.getenv("PYODIDE_SERVE_LOCALLY", 0)))
-
-    PDFJS_VERSION = os.getenv("PDFJS_VERSION", DEFAULT_VERSIONS['pdf'])
-    # Note: We cannot use jsdelivr to serve pdfjs, since (a) it will not serve
-    # html, and (b) pdfjs uses a worker, which must come from the same origin
-    # as the html. Eventually we may provide a config option to set the URL
-    # from which pdfjs's `viewer.html` should be served.
 
     # When loading locally from `/static/...`, some assets have a debug version.
     ELK_DEBUG = bool(int(os.getenv("ELK_DEBUG", 0)))

--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ cp = ConfigParser()
 cp.read(os.path.join(BASE_DIR, 'pfsc.ini'))
 DEFAULT_VERSIONS = {
     name: cp.get('versions', name)
-    for name in ['ise', 'elkjs', 'mathjax', 'pyodide', 'examp', 'pdf']
+    for name in ['ise', 'pyodide', 'examp', 'pdf']
 }
 
 
@@ -177,11 +177,9 @@ class Config:
     ISE_SERVE_LOCALLY = bool(int(os.getenv("ISE_SERVE_LOCALLY", 1)))
     ISE_SERVE_MINIFIED = bool(int(os.getenv("ISE_SERVE_MINIFIED", 0)))
 
-    ELKJS_VERSION = os.getenv("ELKJS_VERSION", DEFAULT_VERSIONS['elkjs'])
     # boolean: false means serve via jsdelivr
     ELKJS_SERVE_LOCALLY = bool(int(os.getenv("ELKJS_SERVE_LOCALLY", 0)))
 
-    MATHJAX_VERSION = os.getenv("MATHJAX_VERSION", DEFAULT_VERSIONS['mathjax'])
     # boolean: false means serve via jsdelivr
     MATHJAX_SERVE_LOCALLY = bool(int(os.getenv("MATHJAX_SERVE_LOCALLY", 0)))
 

--- a/config.py
+++ b/config.py
@@ -30,9 +30,6 @@ if bool(int(os.getenv("LOAD_PFSC_CONF_FROM_STANDARD_DEPLOY_DIR", 0))):
     load_dotenv(PFSC_CONF_PATH, override=True)
 
 
-DEFAULT_ISE_VERSION = '25.0'
-
-
 def format_url_prefix(raw):
     """
     Ensure that the URL prefix is a string that is either empty or
@@ -165,7 +162,7 @@ class Config:
 
     # Static assets:
 
-    ISE_VERSION = os.getenv("ISE_VERSION", DEFAULT_ISE_VERSION)
+    ISE_VERSION = os.getenv("ISE_VERSION", "0.0")
     ISE_SERVE_MINIFIED = bool(int(os.getenv("ISE_SERVE_MINIFIED", 0)))
     # Since a worker script must obey the same-origin policy
     #   https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker

--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ cp = ConfigParser()
 cp.read(os.path.join(BASE_DIR, 'pfsc.ini'))
 DEFAULT_VERSIONS = {
     name: cp.get('versions', name)
-    for name in ['ise', 'pyodide', 'examp', 'pdf']
+    for name in ['ise', 'pdf']
 }
 
 
@@ -173,25 +173,19 @@ class Config:
     # Static assets:
 
     ISE_VERSION = os.getenv("ISE_VERSION", DEFAULT_VERSIONS['ise'])
-    # boolean: false means serve via jsdelivr
-    ISE_SERVE_LOCALLY = bool(int(os.getenv("ISE_SERVE_LOCALLY", 1)))
     ISE_SERVE_MINIFIED = bool(int(os.getenv("ISE_SERVE_MINIFIED", 0)))
-
-    # boolean: false means serve via jsdelivr
-    ELKJS_SERVE_LOCALLY = bool(int(os.getenv("ELKJS_SERVE_LOCALLY", 0)))
-
-    # boolean: false means serve via jsdelivr
-    MATHJAX_SERVE_LOCALLY = bool(int(os.getenv("MATHJAX_SERVE_LOCALLY", 0)))
-
-    PYODIDE_VERSION = os.getenv("PYODIDE_VERSION", DEFAULT_VERSIONS['pyodide'])
-    # boolean: false means serve via jsdelivr
-    PYODIDE_SERVE_LOCALLY = bool(int(os.getenv("PYODIDE_SERVE_LOCALLY", 0)))
-
     # Since a worker script must obey the same-origin policy
     #   https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker
     # we cannot serve the mathworker script over a CDN. However, we can decide
     # whether to serve it minified or not.
     MATHWORKER_SERVE_MINIFIED = bool(int(os.getenv("MATHWORKER_SERVE_MINIFIED", 1)))
+
+    # From where should static assets be obtained?
+    # "locally" means from pfsc-server; otherwise via jsdelivr
+    ISE_SERVE_LOCALLY = bool(int(os.getenv("ISE_SERVE_LOCALLY", 1)))
+    ELKJS_SERVE_LOCALLY = bool(int(os.getenv("ELKJS_SERVE_LOCALLY", 0)))
+    MATHJAX_SERVE_LOCALLY = bool(int(os.getenv("MATHJAX_SERVE_LOCALLY", 0)))
+    PYODIDE_SERVE_LOCALLY = bool(int(os.getenv("PYODIDE_SERVE_LOCALLY", 0)))
 
     PDFJS_VERSION = os.getenv("PDFJS_VERSION", DEFAULT_VERSIONS['pdf'])
     # Note: We cannot use jsdelivr to serve pdfjs, since (a) it will not serve
@@ -201,24 +195,6 @@ class Config:
 
     # When loading locally from `/static/...`, some assets have a debug version.
     ELK_DEBUG = bool(int(os.getenv("ELK_DEBUG", 0)))
-
-    # Micropip install targets:
-    #
-    # Python wheels will be loaded by Pyodide in the client in one of two ways:
-    # Either we pull pfsc-examp from PyPI, and let micropip automatically resolve
-    # its dependencies and pull those too from PyPI; or all wheels will be loaded
-    # via static URLs pointing into pfsc-server. Generally speaking, the former
-    # is what you want when running an online web app, while the latter is
-    # appropriate both when running the OCA, and during development.
-    #
-    # To load all wheels from PyPI, you must define PFSC_EXAMP_VERSION,
-    # whose value should be a string like "0.22.8", and you must _not_ define
-    # LOCAL_WHL_FILENAMES.
-    #
-    # To load all wheels from pfsc-server via static URLs, define LOCAL_WHL_FILENAMES
-    # to be a comma-delimited list of wheel filenames, like displaylang-0.22.8-py3-none-any.whl
-    PFSC_EXAMP_VERSION = os.getenv("PFSC_EXAMP_VERSION", DEFAULT_VERSIONS['examp'])
-    LOCAL_WHL_FILENAMES = parse_cd_list(os.getenv('LOCAL_WHL_FILENAMES', ''))
 
     # See <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy>
     REFERRER_POLICY = os.getenv("REFERRER_POLICY", 'no-referrer')

--- a/pfsc.ini
+++ b/pfsc.ini
@@ -1,7 +1,5 @@
 [versions]
 ise = 23.3
-elkjs = 0.8.1
-mathjax = 3.0.1
 pyodide = 0.21.0
 examp = 0.22.8
 pdf = 3.0.0

--- a/pfsc.ini
+++ b/pfsc.ini
@@ -1,5 +1,3 @@
 [versions]
 ise = 23.3
-pyodide = 0.21.0
-examp = 0.22.8
 pdf = 3.0.0

--- a/pfsc.ini
+++ b/pfsc.ini
@@ -1,3 +1,0 @@
-[versions]
-ise = 23.3
-pdf = 3.0.0

--- a/pfsc/handlers/app.py
+++ b/pfsc/handlers/app.py
@@ -811,29 +811,8 @@ class AppLoader(Handler):
 
         ise_bundle_filename = f'ise.bundle{".min." if check_config("ISE_SERVE_MINIFIED") else "."}js'
         ise_vers = check_config("ISE_VERSION")
-        elk_vers = check_config("ELKJS_VERSION")
-        mathjax_vers = check_config("MATHJAX_VERSION")
 
         js = [
-            # MathJax
-            (
-                url_for('static', filename=f'mathjax/v{mathjax_vers}/tex-svg.js')
-                if check_config("MATHJAX_SERVE_LOCALLY") else
-                f'https://cdn.jsdelivr.net/npm/mathjax@{mathjax_vers}/es5/tex-svg.js'
-            ),
-
-            # ELK.js
-            (
-                url_for(
-                    'static',
-                    filename=f'elk/v{elk_vers}/elk{"-api" if check_config("ELK_DEBUG") else ".bundled"}.js'
-                )
-                if check_config("ELKJS_SERVE_LOCALLY") else
-                f'https://cdn.jsdelivr.net/npm/elkjs@{elk_vers}/lib/elk.bundled.js'
-            ),
-            # If using KLay instead of ELK:
-            # url_for('static', filename='klay/klay.js'),
-
             # the ISE bundle
             (
                 url_for('static', filename=f'ise/v{ise_vers}/{ise_bundle_filename}')
@@ -845,6 +824,24 @@ class AppLoader(Handler):
             # url_for('static', filename='pdfjs/build/pdf.js'),
             # url_for('static', filename='pdfjs/web/pdf_viewer.js'),
         ]
+
+        other_scripts = {
+            'mathjax': (
+                url_for('static', filename='mathjax/vVERSION/tex-svg.js')
+                if check_config("MATHJAX_SERVE_LOCALLY") else
+                'https://cdn.jsdelivr.net/npm/mathjax@VERSION/es5/tex-svg.js'
+            ),
+            'elkjs': (
+                url_for(
+                    'static',
+                    filename=f'elk/vVERSION/elk{"-api" if check_config("ELK_DEBUG") else ".bundled"}.js'
+                )
+                if check_config("ELKJS_SERVE_LOCALLY") else
+                'https://cdn.jsdelivr.net/npm/elkjs@VERSION/lib/elk.bundled.js'
+            ),
+            # If using KLay instead of ELK:
+            # url_for('static', filename='klay/klay.js'),
+        }
 
         def adapt_wheel_target(t):
             if t.endswith('.whl') and not t.startswith('https:'):
@@ -887,5 +884,6 @@ class AppLoader(Handler):
             title="Proofscape ISE",
             ISE_state=json.dumps(ISE_state, indent=4),
             examp_config=json.dumps(examp_config, indent=4),
+            other_scripts=json.dumps(other_scripts, indent=4),
         )
         return html

--- a/pfsc/handlers/app.py
+++ b/pfsc/handlers/app.py
@@ -750,7 +750,7 @@ class AppLoader(Handler):
             'prpoURL': current_app.config.get("PRPO_URL"),
             'prpoVersion': current_app.config.get("PRPO_VERSION"),
             'loginsPossible': logins_are_possible(),
-            'pdfjsURL': url_for('static', filename=f'pdfjs/v{current_app.config["PDFJS_VERSION"]}/web/viewer.html'),
+            'pdfjsURL': url_for('static', filename='pdfjs/vVERSION/web/viewer.html'),
         }
 
         if current_app.config["IS_OCA"]:

--- a/pfsc/templates/ise.html
+++ b/pfsc/templates/ise.html
@@ -40,6 +40,9 @@
 <script>
   pfsc_examp_config = {{ examp_config|safe }};
 </script>
+<script>
+  pfsc_other_scripts = {{ other_scripts|safe }};
+</script>
 {% endblock %}
 
 {% block postjs %}


### PR DESCRIPTION
We have had a D.R.Y. problem with the version numbers for certain JS dependencies.
This and companion PRs in the other projects make it so these numbers are set only in `pfsc-ise`,
and no longer appear as config vars in `pfsc-server` and `pfsc-manage`.