### PR TITLE
Improve manifest info for MODULE nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.25.1 (------)
 
+Improvements:
+
+* Record more useful information in the manifest. For MODULE nodes, we now
+  provide both `isTerminal` and `hasSubmodules`.
+
 Upgrades:
 
 * `pytest==7.2.0` addresses a Dependabot alert re `py<=1.11.0`.

--- a/pfsc/build/__init__.py
+++ b/pfsc/build/__init__.py
@@ -671,6 +671,8 @@ class Builder:
         self.monitor.note_module_parsed()
         self.modules[module.libpath] = module
 
+        manifest_node.update_data({'isTerminal': module.isTerminal()})
+
         # Grab all the items.
         all_items = module.getNativeItemsInDefOrder(hoist_expansions=True)
         self.monitor.set_num_module_items(len(all_items))

--- a/pfsc/build/manifest.py
+++ b/pfsc/build/manifest.py
@@ -260,6 +260,12 @@ class ManifestTreeNode:
         self.children = []
         self.data['libpath'] = id_
 
+    def update_data(self, d):
+        """
+        Pass a dictionary of pairs with which to update this node's data.
+        """
+        self.data.update(d)
+
     def build_dict(self):
         """
         :return: A dictionary representation of this object, suitable for writing as JSON.
@@ -298,13 +304,11 @@ class ManifestTreeNode:
         items.append(d)
         am_module = self.is_module()
         if am_module:
-            # A module is assumed terminal until proven otherwise.
-            d["terminal"] = True
+            d["hasSubmodules"] = False
         for i, child in enumerate(self.children):
             if child.is_module():
                 if am_module:
-                    # We have at least one child that is a module, so we are not terminal.
-                    d["terminal"] = False
+                    d["hasSubmodules"] = True
                 if not recursive:
                     continue
             child.build_relational_model(items, recursive=recursive, siblingOrder=i)

--- a/pfsc/lang/modules.py
+++ b/pfsc/lang/modules.py
@@ -82,6 +82,10 @@ class PfscModule(PfscObj):
     def isSpecial(self):
         return self.libpath.startswith('special.')
 
+    def isTerminal(self):
+        pi = PathInfo(self.libpath)
+        return pi.is_file
+
     def setRepresentedVersion(self, vers):
         self.represented_version = vers
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -20,6 +20,7 @@ import json
 
 from pfsc.build.manifest import (
     build_manifest_from_dict,
+    load_manifest,
     Manifest,
     ManifestTreeNode,
 )
@@ -329,3 +330,33 @@ def test_merge_04():
     m02_cat.merge(m02_mod)
     d = show(m02_cat)
     assert d == manifest_02_c_MOD
+
+
+def test_is_terminal(repos_ready):
+    """Check the `isTerminal` property."""
+    manifest = load_manifest('test.alex.math', version='v3.0.0')
+    root = manifest.get_root_node()
+    model = []
+    root.build_relational_model(model)
+    for info in model:
+        lp = info['libpath']
+        if lp == 'test.alex.math.thm1':
+            # If terminal, then definitely has no submodules.
+            assert info['isTerminal'] is True
+            assert info['hasSubmodules'] is False
+        if lp == 'test.alex.math':
+            # If non-terminal, may have submodules, but also may not (see below).
+            assert info['isTerminal'] is False
+            assert info['hasSubmodules'] is True
+
+    manifest = load_manifest('test.hist.lit', version='v0.0.0')
+    root = manifest.get_root_node()
+    model = []
+    root.build_relational_model(model)
+    for info in model:
+        lp = info['libpath']
+        if lp == 'test.hist.lit.H.ilbert.ZB.Thm9':
+            # Here is a case where the module is non-terminal but (currently)
+            # has no submodules.
+            assert info['isTerminal'] is False
+            assert info['hasSubmodules'] is False


### PR DESCRIPTION
Fixes #5 

* The old `terminal` property is negated and renamed to `hasSubmodules`.
* We add an `isTerminal` property which accurately indicates the filesystem realization of the module, i.e. is it a mere file (terminal) or a dir with a dunder module (non-terminal).