### PR TITLE
meson: Improve factoring of edges through method nodes

### DIFF
--- a/tests/resources/repo/foo/bar/v16/expansions.pfsc
+++ b/tests/resources/repo/foo/bar/v16/expansions.pfsc
@@ -1,0 +1,122 @@
+
+from ..results import Pf
+
+deduc X of Pf.S {
+
+    asrt A1 {
+        en = "A thing that helps to clarify"
+    }
+
+    asrt A2 {
+        en = "Another thing"
+    }
+
+    meson="
+    Pf.S by A1 and A2 and Pf.R.
+    "
+
+}
+
+anno Notes1 @@@
+Some enlightening notes...
+with a <chart:w10>[chart widget with *cool equation* $@e sup i pie; + 1 = 0$ in the label]{
+    "view": "Pf"
+}
+This time we give it its own name, and even put it in a different pane group.
+Now let's add checkboxes.
+<chart:w20>[]{
+    "view": "X",
+    "group": 2,
+    "checkboxes": {
+        "deducs": "Pf"
+    }
+}
+@@@
+
+anno Notes2 @@@
+And let's also add another annotation. This time, let's have
+<qna:q1>[a widget where]{
+    "question":"one of the strings",
+    "answer":"has an unmatched open brace ({) in it"
+}
+and
+<qna:q2>[another widget where]{
+    "question":"one of the strings",
+    "answer":"has an unmatched close brace (}) in it"
+}
+and while we're at it, let's have
+<qna:q3>[a widget where]{
+    "question":"one of the strings",
+    "answer":"is
+             multiline,
+             and has an escaped quotation mark (\") within it.
+             "
+}
+and just for good measure, let's have
+<qna:q4>[a widget where]{
+    "question":"one of the strings",
+    "answer":"combines
+          several
+               of
+                   these
+               }}}{{{{}{}{ \"\"   {\"  }}} \" {{{{}} }{ {{ \"
+             things.
+             "
+}
+@@@
+
+anno Notes3 @@@
+# Testing goal widget altpaths
+
+<goal:w1>[This is a goal]{
+    altpath: "Notes3.w2"
+}
+
+<goal:w2>[This is another goal]{
+    altpath: "w2"
+}
+
+<goal:w3>[This is yet another goal]{
+}
+@@@
+
+# This time we test our expanded JSON syntax wherein
+# you may use libpaths as long as they resolve within
+# the scope where we're working.
+obj1 = {
+    foo: ["bar", 3, true, false, null]
+}
+
+obj2 = {
+    spam: obj1
+}
+
+anno Notes4 @@@
+This <label:>[widget]{
+    will: "define some extra",
+    stuff: obj2
+}
+@@@
+
+# We also need to test whether we correctly ignore # chars occurring within
+# strings (i.e. do _not_ strip them out as comments).
+# Also in this version I moved some words around in the last two comment lines,
+# so we can test out our Git-style merge conflict function, by comparing v11
+# and v12.
+
+This_is_a_string = "that has a # char and an escaped \" char inside of it."
+Here_is_a_single_quoted_string = 'that has a # char and an escaped \' char.'
+
+anno Notes4 @@@
+
+If the server is configured so that param and disp widgets are not allowed in
+untrusted repos, then this module should fail to load, since `test.foo.bar` is
+untrusted.
+
+<disp:eg1_disp1>[]{
+    build: "
+return 'foo'
+",
+}
+
+@@@

--- a/tests/resources/repo/foo/bar/v16/results.pfsc
+++ b/tests/resources/repo/foo/bar/v16/results.pfsc
@@ -1,0 +1,65 @@
+
+deduc Thm {
+
+    asrt C {
+        en = "Some amazing theorem statement."
+    }
+
+    meson = "C"
+
+}
+
+deduc Pf of Thm.C {
+
+    asrt R {
+        en = "Something self-evident"
+    }
+
+    asrt S {
+        en = "An easy consequence"
+    }
+
+    meson = "
+    R, so S, therefore Thm.C
+    "
+
+}
+
+deduc Thm2 {
+    supp S {
+        sy="$S$"
+    }
+    asrt A {
+        sy="$A$"
+    }
+    meson="Suppose S. Then A."
+}
+
+
+deduc Pf2 of Thm2.A {
+
+    asrt B {
+        sy="$B$"
+    }
+
+    mthd M wolog {
+        en="
+        Adding an
+        appropriate constant
+        to $f(x)$
+        "
+    }
+
+    asrt C {
+        sy="$C$"
+    }
+
+    # ISSUE @v0.25.0: https://github.com/proofscape/pfsc-server/issues/7
+    # Meson script should not say `by B` (since it is redundant).
+    # If you delete that, it builds just fine.
+    # However, with it, not only does it fail to build, but the build process crashes.
+    meson="
+    From Thm2.S get B.
+    Then C, by B, applying M, hence Thm2.A.
+    "
+}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -130,20 +130,20 @@ def test_full_build(app, libpath, rec):
         cb = Builder(libpath, recursive=rec, verbose=False)
         build_module(cb)
 
+
 # Try full build on different branches.
-@pytest.mark.skip("Not working with new framework...")
-@pytest.mark.parametrize("libpath, branch, n", (
-    ("test.foo.bar", "v0", 1),
-    ("test.foo.bar.expansions", "v2", 2),
+@pytest.mark.skip(reason="just for manual testing")
+@pytest.mark.parametrize("libpath, branch, rec", (
+    ("test.foo.bar.results", "v16", False),
+    #("test.foo.bar.expansions", "v2", True),
 ))
-def test_update_build(app, libpath, branch, n):
+@pytest.mark.psm
+def test_full_build_at_version(app, libpath, branch, rec):
     with app.app_context():
         ri = get_repo_info(libpath)
         ri.checkout(branch)
-        build_module(libpath, recursive=True, caching=0)
-        manifest = load_manifest(libpath)
-        bi = manifest.get_build_info()
-        assert len(bi) == n
+        cb = Builder(libpath, recursive=rec, verbose=False)
+        build_module(cb)
 
 
 from tests.util import clear_all_indexing, get_basic_repos

--- a/tests/test_meson.py
+++ b/tests/test_meson.py
@@ -18,6 +18,7 @@
 
 import pytest
 
+from pfsc.build.repo import checkout, get_repo_info
 from pfsc.excep import PfscExcep, PECode
 from pfsc.lang.meson import build_graph_from_meson, build_graph_from_arcs
 from pfsc.lang.modules import load_module
@@ -48,8 +49,8 @@ A10 --> A20
 A10
 A20
 M30
-M30 --> A20
 A10 --> M30
+M30 --> A20
 """),
     # (3)
     ("A10. But suppose S20 and S30 and S40. Then A50.", """\
@@ -189,18 +190,18 @@ I140 --> A150
 A150 --> A160
 A160 --> E170
 E180 --> A190
-M210 --> A220
 I200 --> M210
 A190 --> M210
 E170.A35 --> M210
+M210 --> A220
 A220 --> A230
 E240 --> A250
 A250 --> A270
 A130 --> A280
 A280 --> A290
-M300 --> A310
 A290 --> M300
 A230 --> M300
+M300 --> A310
 A310 --> A320
 A320 ..> D330
 A340 --> Pf.Cs1.Cs1C.F
@@ -377,6 +378,52 @@ def test_bar(app):
         print()
         print(g)
         assert g == arclist_with_intr_graph
+
+
+Pf2_edges = [
+    {
+        "tail": "test.foo.bar.results.Pf2.Thm2.S",
+        "head": "test.foo.bar.results.Pf2.B",
+        "style": "ded",
+        "bridge": True
+    },
+    {
+        "tail": "test.foo.bar.results.Pf2.B",
+        "head": "test.foo.bar.results.Pf2.M",
+        "style": "ded",
+        "bridge": False
+    },
+    {
+        "tail": "test.foo.bar.results.Pf2.M",
+        "head": "test.foo.bar.results.Pf2.C",
+        "style": "ded",
+        "bridge": False
+    },
+    {
+        "tail": "test.foo.bar.results.Pf2.C",
+        "head": "test.foo.bar.results.Pf2.Thm2.A",
+        "style": "ded",
+        "bridge": True
+    }
+]
+
+
+@pytest.mark.psm
+def test_issue_7(app):
+    """
+    See https://github.com/proofscape/pfsc-server/issues/7
+    """
+    with app.app_context():
+        libpath = "test.foo.bar.results"
+        version = "v16.0.0"
+        ri = get_repo_info(libpath)
+        with checkout(ri, version):
+            mod = load_module(libpath)
+            dg = mod['Pf2'].buildDashgraph()
+            #import json
+            #print(json.dumps(dg['edges'], indent=4))
+            assert dg['edges'] == Pf2_edges
+
 
 ######################################################################
 # Manual testing


### PR DESCRIPTION
Fixes #7 

We rewrite the method, both simplifying it, and preventing crashes in cases of repeated edges in the incoming list `E`.